### PR TITLE
switch to curl; wget not available in Git Bash

### DIFF
--- a/02_activities/assignments/assignment.sh
+++ b/02_activities/assignments/assignment.sh
@@ -14,7 +14,7 @@ touch README.md
 touch analysis/main.py
 
 # download client data
-wget -O rawdata.zip https://github.com/UofT-DSI/shell/raw/refs/heads/main/02_activities/assignments/rawdata.zip
+curl -Lo rawdata.zip https://github.com/UofT-DSI/shell/raw/refs/heads/main/02_activities/assignments/rawdata.zip
 unzip rawdata.zip
 
 ###########################################


### PR DESCRIPTION
in assignment.sh template, update the data package download command from wget to curl.
- wget is not available by default in Git Bash