### PR TITLE
move bash quick reference to main materials directory, minor autograder tweaks

### DIFF
--- a/01_materials/bash_quick_reference.md
+++ b/01_materials/bash_quick_reference.md
@@ -1,4 +1,4 @@
-# 🐚 Bash Commands Cheatsheet
+# Bash Commands Reference
 
 ## 📋 Commands Overview
 
@@ -101,7 +101,8 @@ alias showhistory="clear; tail -n0 -F ~/.bash_history | nl"
 * -n0: display no lines currently in the file
 * -F: watch the file for changes and display any new lines
 * ~/.bash_history: command history file for bash
-* | nl: number the lines of the input
+* | nl: line numbering
+
 #### To display live updated command history, run this in a separate window:
 showhistory
 

--- a/03_instructional_team/autograder/autograder.py
+++ b/03_instructional_team/autograder/autograder.py
@@ -118,7 +118,7 @@ if len(indx) > 0:
             'comment': '`ls` command run on wrong directory'
         })
 else:
-    s.append({'question': qn, 'status': 0, 'comment': '`ls` command not run'})
+    s.append({'question': f'Part 1 - Q{qn:d}', 'status': 0, 'comment': '`ls` command not run'})
 
 ############################################################################################################
 # Step 4: Check that in 'data/processed', the directories server_logs, user_logs, and event_logs were created
@@ -274,11 +274,11 @@ try:
         'coworker-changes',
     )
     if result:
-        s.append({'question': 'Part 2 - Q1', 'status': 1})
+        s.append({'question': 'Part 2', 'status': 1})
     else:
         s.append({
             'question':
-            'Part 2 - Q1',
+            'Part 2',
             'status':
             0,
             'comment':
@@ -287,7 +287,7 @@ try:
 
 except Exception as e:
     s.append({
-        'question': 'Part 2 - Q1',
+        'question': 'Part 2',
         'status': pd.NA,
         'comment': f'Error checking git commit history.'
     })


### PR DESCRIPTION
The changes involve renaming and updating the bash reference document, as well as modifying the autograder script to improve clarity in the feedback provided.

Updates to bash reference document:

* Renamed `04_this_cohort/additional_resources/bash_commands_cheatsheet.md` to `01_materials/bash_quick_reference.md` and updated the title from "Bash Commands Cheatsheet" to "Bash Commands Reference".
* Simplified the description for the `| nl` command from "number the lines of the input" to "line numbering".