### PR TITLE
Specify PR title in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+<!-- PULL REQUEST TITLE: UofT-DSI | <Module Name> - Assignment <assignment number>-->
+
 ## What changes are you trying to make? (e.g. Adding or removing code, refactoring existing code, adding reports)
 
 ## What did you learn from the changes you have made?


### PR DESCRIPTION
Update PR template to specify PR title template, so participants don't have to refer to the guide every time they create a PR.