### PR TITLE
"incorrect repo message" and auto-close applies to all PRs that don't c…

### DIFF
--- a/.github/workflows/automatic_pr_comment.yaml
+++ b/.github/workflows/automatic_pr_comment.yaml
@@ -32,7 +32,22 @@ jobs:
               isMember = false;
             }
 
-            if (!isMember || branchName.startsWith('assignment') || pr.base.ref !== 'main') {
+            // Check if user is a contributor to the repo
+            try {
+              const contributors = await github.paginate(
+                github.rest.repos.listContributors,
+                {
+                  owner: repo.owner,
+                  repo: repo.repo,
+                  anon: false
+                }
+              );
+              isContributor = contributors.some(contributor => contributor.login === sender);
+            } catch (error) {
+              isContributor = false;
+            }
+
+            if ((!isMember && !isContributor) || branchName.startsWith('assignment')) {
               const commentBody = `This pull request was made to the wrong repository. If you are a participant, please close it and open it in your own fork instead. Refer to the [Assignment Submission Guide](https://github.com/UofT-DSI/onboarding/blob/main/onboarding_documents/submissions.md) for detailed instructions.`;
 
               await github.rest.issues.createComment({

--- a/.github/workflows/automatic_pr_comment.yaml
+++ b/.github/workflows/automatic_pr_comment.yaml
@@ -9,7 +9,7 @@ jobs:
     if: github.repository_owner == 'UofT-DSI'
     runs-on: ubuntu-latest
     steps:
-      - name: Handle PR based on source branch
+      - name: Handle PR based on branch and author
         uses: actions/github-script@v6
         with:
           script: |
@@ -17,11 +17,24 @@ jobs:
             const branchName = pr.head.ref;
             const issue_number = pr.number;
             const repo = context.repo;
+            const sender = context.payload.sender.login;
 
-            if (branchName.startsWith('assignment')) {
-              const commentBody = `This pull request was made to the wrong repository. Please open it in your own fork instead. Refer to the [Assignment Submission Guide](https://github.com/UofT-DSI/onboarding/blob/main/onboarding_documents/submissions.md) for detailed instructions.`;
+            // Check if user is a member of the org
+            let isMember = false;
+            try {
+              const membership = await github.rest.orgs.getMembershipForUser({
+                org: repo.owner,
+                username: sender
+              });
+              isMember = membership && membership.status === "active";
+            } catch (error) {
+              // If not a member, GitHub API throws a 404
+              isMember = false;
+            }
 
-              // Comment on the PR
+            if (!isMember || branchName.startsWith('assignment') || pr.base.ref !== 'main') {
+              const commentBody = `This pull request was made to the wrong repository. If you are a participant, please close it and open it in your own fork instead. Refer to the [Assignment Submission Guide](https://github.com/UofT-DSI/onboarding/blob/main/onboarding_documents/submissions.md) for detailed instructions.`;
+
               await github.rest.issues.createComment({
                 owner: repo.owner,
                 repo: repo.repo,
@@ -29,7 +42,6 @@ jobs:
                 body: commentBody
               });
 
-              // Close the PR
               await github.rest.pulls.update({
                 owner: repo.owner,
                 repo: repo.repo,

--- a/.github/workflows/automatic_pr_comment.yaml
+++ b/.github/workflows/automatic_pr_comment.yaml
@@ -19,8 +19,10 @@ jobs:
             const repo = context.repo;
             const sender = context.payload.sender.login;
 
-            // Check if user is a member of the org
             let isMember = false;
+            let isContributor = false;
+
+            // Check if user is a member of the org
             try {
               const membership = await github.rest.orgs.getMembershipForUser({
                 org: repo.owner,

--- a/.github/workflows/automatic_pr_comment.yaml
+++ b/.github/workflows/automatic_pr_comment.yaml
@@ -2,7 +2,7 @@ name: UofT-DSI Main Repository PR Workflow
 
 on:
   pull_request_target:
-    types: [opened, synchronize]
+    types: [opened, reopened]
 
 jobs:
   handle-pr:


### PR DESCRIPTION
Opening discussion on this change:

- This is a more aggressive strategy to auto-close PRs to the main UofT-DSI repo
- PRs are auto-closed with the "incorrect repo" message for learners if the submitter is both:
  - not part of the UofT-DSI organization, AND
  - not a contributor to the `UofT-DSI/shell` repo
- All instructors should already be members of the organization and be contributors to the repo

This strategy will also catch the recent PRs that made it to `UofT-DSI/shell` because the source branch was not named `assignment`.

However, this will also restrict course content suggestions from learners.