### PR TITLE
Fix autograder PR review permissions

### DIFF
--- a/.github/workflows/autograder.yml
+++ b/.github/workflows/autograder.yml
@@ -8,6 +8,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   autograder:
     name: Assignment autograder

--- a/03_instructional_team/autograder/autograder.py
+++ b/03_instructional_team/autograder/autograder.py
@@ -323,16 +323,18 @@ if github_token:
 
     if correct == total:
         # also approve the PR
-        requests.post(
+        response = requests.post(
             f"https://api.github.com/repos/{github_repo_owner}/{github_repo_name}/pulls/{github_pr_number}/reviews",
             json={"event": "APPROVE", "body": "## Autograder results\n" + render_md },
             headers=headers)
+        response.raise_for_status()
     else:
         # request changes to the PR
-        requests.post(
+        response = requests.post(
             f"https://api.github.com/repos/{github_repo_owner}/{github_repo_name}/pulls/{github_pr_number}/reviews",
             json={"event": "REQUEST_CHANGES", "body": "## Autograder results\n" + render_md + "\n\nPlease address the issues listed above." },
             headers=headers)
+        response.raise_for_status()
 
 else:
     print("GitHub token not found. Skipping comment creation.")


### PR DESCRIPTION
## Summary

The autograder approval flow used to work, but recently it stopped posting approvals or change requests even when the tests passed. We traced the likely cause to GitHub Actions token permissions: newer forked repositories can default to read-only `GITHUB_TOKEN` permissions, which lets the autograder run but prevents it from approving or requesting changes on the PR.

This PR adds the possible fix by explicitly granting the workflow permission to write pull request reviews, and by making the autograder fail visibly if GitHub rejects the review API call.

## Testing

Tested using the same workflow participants follow:

- Forked the repo
- Cloned the fork locally
- Completed the assignment on an `assignment` branch
- Pushed the branch
- Opened a PR from `assignment` into the fork’s `main`
- Confirmed the autograder flow using this receipt PR: [danielrazavi/shell#2](https://github.com/danielrazavi/shell/pull/2)

## Changes

- Adds explicit `pull-requests: write` permission to the autograder workflow.
- Keeps `contents: read` as the minimal repository content permission.
- Raises an error if the GitHub PR review API call fails, instead of silently passing.