### PR TITLE
Update autograder PR feedback flow

### DIFF
--- a/.github/workflows/autograder.yml
+++ b/.github/workflows/autograder.yml
@@ -9,7 +9,11 @@ on:
   workflow_dispatch:
 
 permissions:
+  # Read repository contents for checkout and grading.
   contents: read
+  # Pull request comments use the Issues API.
+  issues: write
+  # Required to create REQUEST_CHANGES reviews when checks fail.
   pull-requests: write
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,13 @@ package.json
 !02_activities/assignments/github_actions.png
 !02_activities/assignments/assignment_instructions.md
 
-.venv
+# Python
+.venv/
+__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
 newproject/

--- a/03_instructional_team/autograder/autograder.py
+++ b/03_instructional_team/autograder/autograder.py
@@ -65,6 +65,17 @@ def is_commit_in_branch(
     return other_commit_sha in commit_shas
 
 
+def post_to_github(url, payload, headers, description):
+    response = requests.post(url, json=payload, headers=headers)
+    if response.ok:
+        print(f'GitHub {description} posted successfully.')
+    else:
+        print(
+            f'GitHub {description} failed with status {response.status_code}: '
+            f'{response.text}')
+    return response
+
+
 # score table
 s = []
 
@@ -320,21 +331,26 @@ if github_token:
         "Authorization": f"Bearer {github_token}",
         "Accept": "application/vnd.github+json"
     }
-
+    comment_body = "## Autograder results\n" + render_md
     if correct == total:
-        # also approve the PR
-        response = requests.post(
-            f"https://api.github.com/repos/{github_repo_owner}/{github_repo_name}/pulls/{github_pr_number}/reviews",
-            json={"event": "APPROVE", "body": "## Autograder results\n" + render_md },
-            headers=headers)
-        response.raise_for_status()
-    else:
+        comment_body += "\n\nAll autograder tests passed. This submission is approved by the autograder."
+
+    post_to_github(
+        f"https://api.github.com/repos/{github_repo_owner}/{github_repo_name}/issues/{github_pr_number}/comments",
+        {"body": comment_body},
+        headers,
+        "comment")
+
+    if correct != total:
         # request changes to the PR
-        response = requests.post(
+        post_to_github(
             f"https://api.github.com/repos/{github_repo_owner}/{github_repo_name}/pulls/{github_pr_number}/reviews",
-            json={"event": "REQUEST_CHANGES", "body": "## Autograder results\n" + render_md + "\n\nPlease address the issues listed above." },
-            headers=headers)
-        response.raise_for_status()
+            {
+                "event": "REQUEST_CHANGES",
+                "body": "Autograder checks failed. Please address the issues listed in the results comment."
+            },
+            headers,
+            "request changes review")
 
 else:
     print("GitHub token not found. Skipping comment creation.")


### PR DESCRIPTION
## Summary

This updates the assignment autograder feedback flow so passing submissions no longer require the GitHub Actions bot to create a formal PR approval.

## Changes

- Always posts autograder results as a normal PR comment.
- Adds an explicit “approved by the autograder” message when all checks pass.
- Keeps `REQUEST_CHANGES` reviews for failing submissions.
- Adds workflow permissions needed for PR comments and request-changes reviews.
- Adds Python cache files/directories to `.gitignore`.

## Why

GitHub blocks Actions-created approval reviews unless the repo setting “Allow GitHub Actions to create and approve pull requests” is enabled. Posting the passing result as a normal PR comment avoids requiring participants to change repository settings, while still preserving request-changes reviews for failed submissions.